### PR TITLE
Add registration endpoint

### DIFF
--- a/demo/settings.py
+++ b/demo/settings.py
@@ -36,16 +36,22 @@ INSTALLED_APPS = [
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",
-    "django.contrib.sessions",
     "django.contrib.messages",
+    "django.contrib.sessions",
     "django.contrib.staticfiles",
+    "django.contrib.sites",
     # Third-Party Apps
+    "allauth",
+    "allauth.account",
+    "rest_auth.registration",
     "rest_framework",
     "rest_framework.authtoken",
     # Local Apps
     "api.apps.ApiConfig",
     "snippets.apps.SnippetsConfig",
 ]
+
+SITE_ID = 1
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",

--- a/demo/urls.py
+++ b/demo/urls.py
@@ -11,7 +11,10 @@ urlpatterns = [
     path("", include("snippets.urls")),
 ]
 
+
+## Authentication URLs
 urlpatterns += [
     path("api-auth/", include("rest_framework.urls")),
     path("api-token-auth/", obtain_auth_token, name="api_token_auth"),
+    path("rest-auth/registration/", include("rest_auth.registration.urls")),
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,9 @@
 Django==3.1.10
 PyYAML==5.4.1
 Pygments==2.9.0
+django-allauth==0.44.0
 django-heroku==0.3.1
+django-rest-auth==0.9.5
 djangorestframework==3.12.4
 gunicorn==20.0.4
 uritemplate==3.0.1


### PR DESCRIPTION
## Description

Adds the endpoint `/rest-auth/registration` to register new users

![image](https://user-images.githubusercontent.com/2728804/118542143-fb711880-b728-11eb-8f30-14c0f5529b56.png)

Closes #17