### PR TITLE
Add configuration settings for production

### DIFF
--- a/demo/settings/common.py
+++ b/demo/settings/common.py
@@ -11,22 +11,10 @@ https://docs.djangoproject.com/en/3.1/ref/settings/
 """
 
 from pathlib import Path
-import django_heroku
 import os
 
 # # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
-
-# Quick-start development settings - unsuitable for production
-# See https://docs.djangoproject.com/en/3.1/howto/deployment/checklist/
-
-# SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = "l^qu9024l%8*h$(&4*e&s3q+vc%gb-^27c5$0qu&ypgsl=_7_u"
-
-# SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
-
-ALLOWED_HOSTS = ["127.0.0.1", "localhost", "demo.scanapi.dev"]
 
 
 # Application definition
@@ -145,5 +133,3 @@ STATIC_URL = "/static/"
 
 # Extra places for collectstatic to find static files.
 STATICFILES_DIRS = (os.path.join(BASE_DIR, "static"),)
-
-django_heroku.settings(locals())

--- a/demo/settings/development.py
+++ b/demo/settings/development.py
@@ -1,0 +1,8 @@
+from demo.settings.common import *
+
+SECRET_KEY = "dev"
+
+# SECURITY WARNING: don't run with debug turned on in production!
+DEBUG = True
+
+ALLOWED_HOSTS = ["127.0.0.1", "localhost"]

--- a/demo/settings/production.py
+++ b/demo/settings/production.py
@@ -1,0 +1,15 @@
+import django_heroku
+from demo.settings.common import *
+
+# Quick-start development settings - unsuitable for production
+# See https://docs.djangoproject.com/en/3.1/howto/deployment/checklist/
+
+# SECURITY WARNING: keep the secret key used in production secret!
+SECRET_KEY = os.environ['SECRET_KEY']
+
+# SECURITY WARNING: don't run with debug turned on in production!
+DEBUG = False
+
+ALLOWED_HOSTS = ["demo.scanapi.dev"]
+
+django_heroku.settings(locals())

--- a/demo/wsgi.py
+++ b/demo/wsgi.py
@@ -11,6 +11,8 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'demo.settings')
+env = os.environ.get('ENVIRONMENT', 'development')
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', f'demo.settings.{env}')
 
 application = get_wsgi_application()

--- a/manage.py
+++ b/manage.py
@@ -6,7 +6,10 @@ import sys
 
 def main():
     """Run administrative tasks."""
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'demo.settings')
+    env = os.environ.get('ENVIRONMENT', 'development')
+    os.environ.setdefault(
+        'DJANGO_SETTINGS_MODULE', f'demo.settings.{env}'
+    )
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:


### PR DESCRIPTION
* Added a demo/settings module for separate runtimes i.e development
and production.
* Updated `wsgi.py` and `manage.py` to dynamically manage environments.

Closes: https://github.com/scanapi/demo-api/issues/25